### PR TITLE
Stdlib tests multiple rubies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Gemfile.lock
 *.gem
+/tmp

--- a/Rakefile
+++ b/Rakefile
@@ -49,7 +49,13 @@ namespace :test do
   ruby_dir = "tmp/ruby/#{tag}"
 
   file ruby_dir do
-    sh "git clone --branch=#{tag} --depth=1 https://github.com/ruby/ruby #{ruby_dir}"
+    sh "git clone --branch=#{tag} --depth=1 https://github.com/ruby/ruby #{ruby_dir}" do |ok, res|
+      next if ok
+
+      puts "#{res}"
+      tag << '_0'
+      sh "git clone --branch=#{tag} --depth=1 https://github.com/ruby/ruby #{ruby_dir}"
+    end
   end
 
   require 'rake/testtask'

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,9 @@ require 'bundler/gem_tasks'
 
 Rake::Task[:build].enhance [ :gemspec ]
 
+require 'rake/clean'
+CLEAN.include 'tmp'
+
 desc "Generate gemspec"
 task :gemspec do
   require 'rubygems/specification'

--- a/Rakefile
+++ b/Rakefile
@@ -41,4 +41,20 @@ end
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new
 
+namespace :test do
+  tag = "v#{RUBY_VERSION.gsub(/\./,'_')}"
+  ruby_dir = "tmp/ruby/#{tag}"
+
+  file ruby_dir do
+    sh "git clone --branch=#{tag} --depth=1 https://github.com/ruby/ruby #{ruby_dir}"
+  end
+
+  require 'rake/testtask'
+  Rake::TestTask.new(:stdlib => ruby_dir) do |t|
+    # ensure subcommand is loaded to catch monkey-patch errors
+    t.test_files = FileList['lib/optparse/subcommand', "#{ruby_dir}/test/optparse/test_*.rb"]
+    t.verbose = true
+  end
+end
+
 task :default => :spec

--- a/Rakefile
+++ b/Rakefile
@@ -67,4 +67,4 @@ namespace :test do
   end
 end
 
-task :default => :spec
+task :default => [ :spec, 'test:stdlib' ]

--- a/Rakefile
+++ b/Rakefile
@@ -34,6 +34,7 @@ task :gemspec do
 
     s.add_development_dependency "rake", "~> 0"
     s.add_development_dependency "rspec", "2.9.0"
+    s.add_development_dependency "test-unit"
   end
 
   File.open("optparse-subcommand.gemspec", "w") do |file|

--- a/optparse-subcommand.gemspec
+++ b/optparse-subcommand.gemspec
@@ -9,13 +9,13 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib".freeze]
   s.authors = ["Bo Jeanes".freeze]
   s.autorequire = "optparse/subcommand".freeze
-  s.date = "2017-04-12"
+  s.date = "2017-04-20"
   s.description = "Add subcommand parsing to Ruby's OptionParser class".freeze
   s.email = "me@bjeanes.com".freeze
   s.files = ["LICENSE".freeze, "README.md".freeze, "lib/optparse".freeze, "lib/optparse/subcommand.rb".freeze, "spec/optparse".freeze, "spec/optparse/subcommand_spec.rb".freeze]
   s.homepage = "http://github.com/bjeanes/optparse-subcommand".freeze
   s.licenses = ["MIT".freeze]
-  s.rubygems_version = "2.6.8".freeze
+  s.rubygems_version = "2.6.11".freeze
   s.summary = "Add subcommand parsing to Ruby's OptionParser class".freeze
   s.test_files = ["spec/optparse".freeze, "spec/optparse/subcommand_spec.rb".freeze]
 
@@ -25,12 +25,15 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_development_dependency(%q<rake>.freeze, ["~> 0"])
       s.add_development_dependency(%q<rspec>.freeze, ["= 2.9.0"])
+      s.add_development_dependency(%q<test-unit>.freeze, [">= 0"])
     else
       s.add_dependency(%q<rake>.freeze, ["~> 0"])
       s.add_dependency(%q<rspec>.freeze, ["= 2.9.0"])
+      s.add_dependency(%q<test-unit>.freeze, [">= 0"])
     end
   else
     s.add_dependency(%q<rake>.freeze, ["~> 0"])
     s.add_dependency(%q<rspec>.freeze, ["= 2.9.0"])
+    s.add_dependency(%q<test-unit>.freeze, [">= 0"])
   end
 end


### PR DESCRIPTION
Pseudo-spike branch; mostly focused on fetching ruby source based on current ruby runtime, so as to have the stdlib test suite for optparse. The ruby source is pulled down via a `file` rake rule which is listed as a pre-req of the `test:stdlib` rake task (which runs just the optparse

- ruby source pulled down via a `file` rake task (under the `test:` namespace)
- `test:stdlib` rake task runs the optparse stdlib suite of tests from ruby source
- the ruby src file task is a pre-req of the `stdlib` task
- includes branch upgrading rspec to 3.x
- fixes gemfile reference of rubygems source (http -> https)
- adds rake's ootb clean/clobber tasks and configures them to remove `tmp` dir (where the ruby source is written) on `clean`
- includes bundler binstubs in `bin/` as convention now
- downgrades rake to 10.x (to support ruby < 1.9.3)
- adds test-unit as dev dependency since it's no longer in StdLib as of ruby 2.2.0

Mostly still WIP. Opening PR for early feedback/discussion.